### PR TITLE
Container Sanity Checker (Issue #20)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ my %WriteMakefileArgs = (
     "Module::Build" => "0.28"
   },
   "DISTNAME" => "Beam-Wire",
-  "EXE_FILES" => [],
+  "EXE_FILES" => ['script/beam-wire'],
   "LICENSE" => "perl",
   "NAME" => "Beam::Wire",
   "PREREQ_PM" => {

--- a/script/beam-wire
+++ b/script/beam-wire
@@ -6,6 +6,7 @@ use warnings;
 use Getopt::Long;
 use Pod::Usage 'pod2usage';
 
+Getopt::Long::Configure("bundling");
 GetOptions(
     'a|all'         => \my $all,
     'i|instantiate' => \my $inst,
@@ -13,19 +14,22 @@ GetOptions(
     'h|?|help'      => \my $help,
 );
 
-pod2usage( -msg => "Please provide a configuration file\n" ) unless @ARGV;
-
 if ($help) {
     pod2usage(
         -msg     => 'test',
         -verbose => 1
     );
 }
+
+pod2usage( -msg => "Please provide a configuration file\n" ) unless @ARGV;
+
 push @INC, 'lib' if $lib;
 
 use Beam::Wire;
 my $wire = Beam::Wire->new( file => $ARGV[0] );
-$wire->validate($inst);
+my $error_count = $wire->validate( $inst, $all );
+
+exit $error_count ? 1 : 0;
 
 =head1 NAME
 
@@ -33,7 +37,7 @@ beam-wire - Validate Beam::Wire configuration files
 
 =head1 SYNOPSIS
 
-  Usage: beam-wire [options] config
+  Usage: beam-wire [options] configuration.file
 
 =head1 OPTIONS
 

--- a/script/beam-wire
+++ b/script/beam-wire
@@ -1,0 +1,46 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Getopt::Long;
+use Pod::Usage 'pod2usage';
+
+GetOptions(
+    'a|all'         => \my $all,
+    'i|instantiate' => \my $inst,
+    'l|lib'         => \my $lib,
+    'h|?|help'      => \my $help,
+);
+
+pod2usage( -msg => "Please provide a configuration file\n" ) unless @ARGV;
+
+if ($help) {
+    pod2usage(
+        -msg     => 'test',
+        -verbose => 1
+    );
+}
+push @INC, 'lib' if $lib;
+
+use Beam::Wire;
+my $wire = Beam::Wire->new( file => $ARGV[0] );
+$wire->validate($inst);
+
+=head1 NAME
+
+beam-wire - Validate Beam::Wire configuration files
+
+=head1 SYNOPSIS
+
+  Usage: beam-wire [options] config
+
+=head1 OPTIONS
+
+ -a, --all             Warn about all errors found instead of quitting after the first
+ -i, --instantiate     Attempt to instantiate all dependencies
+ -l, --lib             Add 'lib' to the path for checking dependency class names
+ -h, --help            Display this help
+ -?                    Display this help
+
+=cut


### PR DESCRIPTION
Add beam-wire script with checks for all but method chain & serial.  This piggybacks on existing exception tests.  Will abort after first error because it is throwing exceptions instead of warning.