### PR TITLE
Avoid YAML::XS 0.61 in Makefile.PL

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,2 +1,3 @@
 Doug Bell <preaction@cpan.org> <madcityzen@gmail.com>
 Doug Bell <preaction@cpan.org> <doug.bell@baml.com>
+Kent Fredric <kentnl@cpan.org> <kentfredric@gmail.com>

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,9 @@ my %WriteMakefileArgs = (
   "ABSTRACT" => "Lightweight Dependency Injection Container",
   "AUTHOR" => "Doug Bell <preaction\@cpan.org>, Al Newkirk <anewkirk\@ana.io>",
   "CONFIGURE_REQUIRES" => {
-    "ExtUtils::MakeMaker" => 0
+    "CPAN::Meta::Requirements" => "2.120620",
+    "ExtUtils::MakeMaker" => 0,
+    "Module::Metadata" => 0
   },
   "DISTNAME" => "Beam-Wire",
   "EXE_FILES" => [],
@@ -66,6 +68,10 @@ my %FallbackPrereqs = (
   "YAML" => 0
 );
 
+# inserted by Dist::Zilla::Plugin::DynamicPrereqs 0.019
+# Breaks LoadFile(path(...))
+has_module('YAML::XS','== 0.61') and requires('YAML::XS','0.62');
+
 
 unless ( eval { ExtUtils::MakeMaker->VERSION(6.63_03) } ) {
   delete $WriteMakefileArgs{TEST_REQUIRES};
@@ -77,3 +83,36 @@ delete $WriteMakefileArgs{CONFIGURE_REQUIRES}
   unless eval { ExtUtils::MakeMaker->VERSION(6.52) };
 
 WriteMakefile(%WriteMakefileArgs);
+
+# inserted by Dist::Zilla::Plugin::DynamicPrereqs 0.019
+sub _add_prereq {
+  my ($mm_key, $module, $version_or_range) = @_;
+  warn "$module already exists in $mm_key -- need to do a sane metamerge!"
+    if exists $WriteMakefileArgs{$mm_key}{$module}
+      and $WriteMakefileArgs{$mm_key}{$module} ne ($version_or_range || 0);
+  warn "$module already exists in FallbackPrereqs -- need to do a sane metamerge!"
+    if exists $FallbackPrereqs{$module} and $FallbackPrereqs{$module} ne ($version_or_range || 0);
+  $WriteMakefileArgs{$mm_key}{$module} = $FallbackPrereqs{$module} = $version_or_range || 0;
+  return;
+}
+
+sub has_module {
+  my ($module, $version_or_range) = @_;
+  require Module::Metadata;
+  my $mmd = Module::Metadata->new_from_module($module);
+  return undef if not $mmd;
+  return $mmd->version($module) if not defined $version_or_range;
+
+  require CPAN::Meta::Requirements;
+  my $req = CPAN::Meta::Requirements->new;
+  $req->add_string_requirement($module => $version_or_range);
+  return 1 if $req->accepts_module($module => $mmd->version($module));
+  return 0;
+}
+
+sub requires { goto &runtime_requires }
+
+sub runtime_requires {
+  my ($module, $version_or_range) = @_;
+  _add_prereq(PREREQ_PM => $module, $version_or_range);
+}

--- a/README.mkdn
+++ b/README.mkdn
@@ -579,6 +579,7 @@ The configuration is invalid:
 
 - Bruce Armstrong <bruce@armstronganchor.net>
 - Bruce Armstrong <bruce@fortressofgeekdom.org>
+- Kent Fredric &lt;kentnl@cpan.org>
 
 # COPYRIGHT AND LICENSE
 

--- a/cpanfile
+++ b/cpanfile
@@ -26,5 +26,7 @@ on 'test' => sub {
 };
 
 on 'configure' => sub {
+  requires "CPAN::Meta::Requirements" => "2.120620";
   requires "ExtUtils::MakeMaker" => "0";
+  requires "Module::Metadata" => "0";
 };

--- a/dist.ini
+++ b/dist.ini
@@ -19,6 +19,8 @@ repository.url  = https://github.com/preaction/Beam-Wire.git
 bugtracker.web  = https://github.com/preaction/Beam-Wire/issues
 repository.type = git
 
+[MetaJSON]
+
 ; --- Module management
 [@Filter]
 -bundle = @Basic

--- a/dist.ini
+++ b/dist.ini
@@ -113,3 +113,8 @@ Test::Deep = 0
 Test::Differences = 0.64 ; Fix buggy Text::Diff version
 Test::Exception = 0
 Test::Lib = 0
+
+[DynamicPrereqs]
+-delimiter = |
+-raw = |# Breaks LoadFile(path(...))
+-raw = |has_module('YAML::XS','== 0.61') and requires('YAML::XS','0.62');


### PR DESCRIPTION
Ideally there should be some Prereq specification that only causes tools to upgrade to 0.62 if, and only if, 0.61 is installed. 

But that's typically hard and confusing.

So the equivalent logic using @ether's [`Dist::Zilla::Plugin::DynamicPrereqs`](https://metacpan.org/pod/Dist::Zilla::Plugin::DynamicPrereqs) is added here.

In the second commit I add `[MetaJSON]` because its just generally recommended to ship one if you want to be a good CPAN Citizen. ( esp wr/t build_requires vs test_requires )

Footnotes:
- I committed generated changes that seemed relevant in the same commit I made them in, wasn't sure if this is protocol or not, but I'm able to fix/wever if required
- There is still a `Build.PL` in the source tree, but nothing seems to update that any more, and this patch has no application to `Build.PL`, and I would fully encourage setting `Build.PL` on fire =)

Closes #57 
