### PR TITLE
add methods to allow modification of class and role module names

### DIFF
--- a/lib/Beam/Wire.pm
+++ b/lib/Beam/Wire.pm
@@ -1048,7 +1048,7 @@ sub validate {
         }
 
         if ($config{class}) {
-            eval "require " . $config{class} if $config{class};
+            eval "require " . $config{class};
         }
         #TODO: check method chain & serial
     }

--- a/lib/Beam/Wire.pm
+++ b/lib/Beam/Wire.pm
@@ -488,10 +488,12 @@ sub create_service {
         );
     }
 
+    $service_info{class} = $self->resolve_class( $service_info{class} );
+
     use_module( $service_info{class} );
 
     if ( my $with = $service_info{with} ) {
-        my @roles = ref $with ? @{ $with } : ( $with );
+        my @roles = map { $self->resolve_role( $_ ) } ref $with ? @{ $with } : ( $with );
         my $class = Moo::Role->create_class_with_roles( $service_info{class}, @roles );
         $service_info{class} = $class;
     }
@@ -889,6 +891,28 @@ sub resolve_ref {
     return @ref;
 }
 
+=method resolve_class
+
+   my $class_name = $self->resolve_class( $class_name );
+
+Resolve C<$class_name>.  By default this simply returns C<$class_name>, but it could
+be used to apply a module namespace prefix or some other transformation.
+
+=cut
+
+sub resolve_class { $_[1] }
+
+=method resolve_role
+
+   my $class_name = $self->resolve_role( $role_name );
+
+Resolve C<$role_name>.  By default this simply returns C<$role_name>, but it could
+be used to apply a module namespace prefix or some other transformation.
+
+=cut
+
+sub resolve_role { $_[1] }
+
 =method fix_refs
 
     my @fixed = $wire->fix_refs( $for_name, @args );
@@ -1048,7 +1072,7 @@ sub validate {
         }
 
         if ($config{class}) {
-            eval "require " . $config{class};
+            eval "require " . $self->resolve_class( $config{class} );
         }
         #TODO: check method chain & serial
     }

--- a/t/service/class.t
+++ b/t/service/class.t
@@ -1,0 +1,35 @@
+
+use Test::More;
+use Test::Exception;
+use Test::Lib;
+use Beam::Wire;
+
+{
+  package ResolveClass;
+  use Moo::Role;
+
+  around 'resolve_class' => sub {
+    my $orig = shift;
+    return 'My::' . $_[1];
+  }
+}
+
+
+subtest 'class with name resolver' => sub {
+    my $wire = Beam::Wire->new(
+        config => {
+            foo => {
+                class => 'ClassTest',
+                args => { foo => bar },
+            },
+        },
+    );
+
+    Moo::Role->apply_roles_to_object( $wire, 'ResolveClass' );
+
+    my $foo;
+    lives_ok { $foo = $wire->get( 'foo' ) };
+    is $foo->foo, 'bar';
+};
+
+done_testing;

--- a/t/service/with.t
+++ b/t/service/with.t
@@ -4,6 +4,7 @@ use Test::Deep;
 use Test::Exception;
 use Test::Lib;
 use Beam::Wire;
+use Moo::Role ();
 
 subtest 'compose a single role' => sub {
     my $wire = Beam::Wire->new(
@@ -48,5 +49,56 @@ subtest 'compose multiple roles' => sub {
     ok $svc->DOES( 'My::CloneRole' );
     cmp_deeply [ $svc->got_args_list ], [ foo => 'bar' ];
     ok $svc->can( 'clone' );
+};
+
+
+{
+  package ResolveRole;
+  use Moo::Role;
+
+  around 'resolve_role' => sub {
+    my $orig = shift;
+    return 'My::' . $_[1];
+  }
+}
+
+subtest 'compose a single role with name resolver' => sub {
+    my $wire = Beam::Wire->new(
+        config => {
+            foo => {
+                class => 'My::ArgsTest',
+                with => 'ArgsListRole',
+            },
+        },
+    );
+
+    Moo::Role->apply_roles_to_object( $wire, 'ResolveRole' );
+
+    my $svc;
+    lives_ok { $svc = $wire->get( 'foo' ) };
+    isa_ok $svc, 'My::ArgsTest';
+    ok $svc->DOES( 'My::ArgsListRole' );
+};
+
+subtest 'compose multiple roles with name resolver' => sub {
+    my $wire = Beam::Wire->new(
+        config => {
+            foo => {
+                class => 'My::ArgsTest',
+                with => [
+                    'ArgsListRole',
+                    'CloneRole',
+                ],
+            },
+        },
+    );
+
+    Moo::Role->apply_roles_to_object( $wire, 'ResolveRole' );
+
+    my $svc;
+    lives_ok { $svc = $wire->get( 'foo' ) };
+    isa_ok $svc, 'My::ArgsTest';
+    ok $svc->DOES( 'My::ArgsListRole' );
+    ok $svc->DOES( 'My::CloneRole' );
 };
 done_testing;


### PR DESCRIPTION
I'd like to make it easier for the user to specify class and roles names.  [Mojolicious](https://metacpan.org/pod/Mojo::Base#with_roles), for example, allows one to specify roles using a `+` prefix to indicate the name is relative to some other package.

This commit add two method to `Beam::Wire`: `resolve_class` and `resolve_role` which are passed the specified name and return the fully resolved name.  (I created separate versions as there might be different rules for them.)