### PR TITLE
install the beam-wire executable

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,6 +15,9 @@ my %WriteMakefileArgs = (
     "Module::Metadata" => 0
   },
   "DISTNAME" => "Beam-Wire",
+  "EXE_FILES" => [
+    "bin/beam-wire"
+  ],
   "LICENSE" => "perl",
   "MIN_PERL_VERSION" => "5.008",
   "NAME" => "Beam::Wire",

--- a/bin/beam-wire
+++ b/bin/beam-wire
@@ -1,5 +1,7 @@
 #!perl
 
+# PODNAME: beam-wire
+
 use strict;
 use warnings;
 


### PR DESCRIPTION
The `beam-wire` executable was not actually being installed.