### PR TITLE
Allow to use false values in Value Services

### DIFF
--- a/lib/Beam/Wire.pm
+++ b/lib/Beam/Wire.pm
@@ -496,7 +496,7 @@ sub create_service {
             error => '"value" cannot be used with "class" or "extends"',
         );
     }
-    if ( $service_info{value} ) {
+    if ( exists $service_info{value} ) {
         return $service_info{value};
     }
 


### PR DESCRIPTION
Added the ability to use empty (false) value in Value Services:
```yml
debug:
  value: 0
foo:
  class: Foo
  args:
    debug:
      $ref: debug
```

Now if you use empty value (0, '', ...) you'll get an error:
```
Invalid config for service 'foo': Service configuration incomplete. Missing one of "class", "value", "config"
```