### PR TITLE
fix exit status

### DIFF
--- a/bin/beam-wire
+++ b/bin/beam-wire
@@ -31,7 +31,7 @@ use Beam::Wire;
 my $wire = Beam::Wire->new( file => $ARGV[0] );
 my $error_count = $wire->validate( $inst, $all );
 
-exit $error_count ? 1 : 0;
+exit($error_count ? 1 : 0);
 
 =head1 NAME
 


### PR DESCRIPTION
`exit` has higher precedence than `?:`, so `exit $error_count ? 1 : 0` parses as `(exit $error_count) ? 1 : 0`, which is not what was intended.